### PR TITLE
Unhide the mod

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -51,5 +51,5 @@ Click, Hurb, Nameless - Minor help with sprites and ideas"
 repo: "GMugXD/qr-mod"
 minGameVersion: 143
 version: 6
-hidden: true
+hidden: false
 dependecies: []


### PR DESCRIPTION
The mod shouldn't be hidden. It adds content, and therefore adds incompatibilities with vanilla servers. Servers that support it will likely have it in their mods folder anyway.

MDN recently had an issue with the mod's incompatibility:
![image](https://github.com/user-attachments/assets/5a6704ad-1403-4e37-9e6e-39494daad56a)
[Link to the above post](https://discord.com/channels/593512071589527562/1384995611618705578/1384995611618705578)

It's better to not cause confusion for players that use your mod.

We know it's this mod since disabling it resolved the issue:
![image](https://github.com/user-attachments/assets/4204e6b3-1186-49b3-a0a1-6d364e083eaf)
